### PR TITLE
Remove direct NodeList accesses

### DIFF
--- a/DamageInfoPlugin/DamageInfoPlugin.cs
+++ b/DamageInfoPlugin/DamageInfoPlugin.cs
@@ -25,14 +25,14 @@ namespace DamageInfoPlugin;
 // ReSharper disable once ClassNeverInstantiated.Global
 public unsafe class DamageInfoPlugin : IDalamudPlugin
 {
-	private const int TargetInfoGaugeBgNodeIndex = 41;
-	private const int TargetInfoGaugeNodeIndex = 43;
+	private const int TargetInfoGaugeBgNodeId = 15;
+	private const int TargetInfoGaugeNodeId = 13;
 
-	private const int TargetInfoSplitGaugeBgNodeIndex = 2;
-	private const int TargetInfoSplitGaugeNodeIndex = 4;
+	private const int TargetInfoSplitGaugeBgNodeId = 7;
+	private const int TargetInfoSplitGaugeNodeId = 5;
 
-	private const int FocusTargetInfoGaugeBgNodeIndex = 13;
-	private const int FocusTargetInfoGaugeNodeIndex = 15;
+	private const int FocusTargetInfoGaugeBgNodeId = 8;
+	private const int FocusTargetInfoGaugeNodeId = 6;
 
 	public string Name => "Damage Info";
 
@@ -312,8 +312,8 @@ public unsafe class DamageInfoPlugin : IDalamudPlugin
 		return new CastbarInfo
 		{
 			unitBase = unitBase,
-			gauge = (AtkImageNode*)unitBase->UldManager.NodeList[TargetInfoGaugeNodeIndex],
-			bg = (AtkImageNode*)unitBase->UldManager.NodeList[TargetInfoGaugeBgNodeIndex]
+			gauge = unitBase->GetImageNodeById(TargetInfoGaugeNodeId),
+			bg = unitBase->GetImageNodeById(TargetInfoGaugeBgNodeId),
 		};
 	}
 
@@ -326,8 +326,8 @@ public unsafe class DamageInfoPlugin : IDalamudPlugin
 		return new CastbarInfo
 		{
 			unitBase = unitBase,
-			gauge = (AtkImageNode*)unitBase->UldManager.NodeList[TargetInfoSplitGaugeNodeIndex],
-			bg = (AtkImageNode*)unitBase->UldManager.NodeList[TargetInfoSplitGaugeBgNodeIndex]
+			gauge = unitBase->GetImageNodeById(TargetInfoSplitGaugeNodeId),
+			bg = unitBase->GetImageNodeById(TargetInfoSplitGaugeBgNodeId),
 		};
 	}
 
@@ -340,8 +340,8 @@ public unsafe class DamageInfoPlugin : IDalamudPlugin
 		return new CastbarInfo
 		{
 			unitBase = unitBase,
-			gauge = (AtkImageNode*)unitBase->UldManager.NodeList[FocusTargetInfoGaugeNodeIndex],
-			bg = (AtkImageNode*)unitBase->UldManager.NodeList[FocusTargetInfoGaugeBgNodeIndex]
+			gauge = unitBase->GetImageNodeById(FocusTargetInfoGaugeNodeId),
+			bg = unitBase->GetImageNodeById(FocusTargetInfoGaugeBgNodeId),
 		};
 	}
 


### PR DESCRIPTION
Fixes an issue where adding custom nodes into the cast bar causes DamageInfo to modify the wrong elements.

VanillaPlus adds a text node as a child to the castbar image node, causing elements below it to shift in position.

The proper way to access nodes is via NodeId and the unit base getter (which also does type checking internally).

Pics are illustrating that these changes were tested and working as expected:

<img width="385" height="135" alt="ffxiv_dx11_leeBG1VSSF" src="https://github.com/user-attachments/assets/ecbcdd7e-3c25-4e55-8de7-650a71b90330" />

<img width="244" height="99" alt="ffxiv_dx11_6AT4kQNN1J" src="https://github.com/user-attachments/assets/747b26d4-7dd4-4010-9227-fedc6f39231f" />

<img width="264" height="116" alt="ffxiv_dx11_gYH9DVGEnZ" src="https://github.com/user-attachments/assets/0ec936a4-1713-4cb6-bbba-0694c27e7831" />
